### PR TITLE
few README notes about CUDA compliancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ using Cython and [nvc++ with stdpar](https://developer.nvidia.com/blog/accelerat
    
    Once installed, please ensure that the `nvc++` executable is in your PATH.
 
+   Further, your GPU must have CUDA capability >= 6.0 to exploit `-stdpar` feature.
+
 2. You will also need the development version of [Cython](https://github.com/cython/cython).
    The simplest way to get the minimum required version is to use `pip`:
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-import  os
+import os
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
 from Cython.Build import cythonize
@@ -21,6 +21,7 @@ if NVCPP_EXE is not None:
     ]
 
 
+# noinspection PyPep8Naming
 class custom_build_ext(build_ext):
     def build_extensions(self):
         if NVCPP_EXE:


### PR DESCRIPTION
Got stuck by

```
$ nvc++ -fPIC -stdpar -gpu=nordc -std=c++17 -Iinclude-stdpar -I/media/xnext/DATAEXT/opt/miniconda/envs/ds38/include/python3.8 -c cppsort_stdpar.cpp -o build/temp.linux-x86_64-3.8/cppsort_stdpar.o -std=c++17
```
> nvc++-Fatal-No GPU detected. Please use '-gpu=ccXY' to generate GPU code and specify compute capability.

Then I tried with my hardware capability (5.0)
```
$ nvc++ -fPIC -stdpar -gpu=cc50 -gpu=nordc -std=c++17 -Iinclude-stdpar -I/media/xnext/DATAEXT/opt/miniconda/envs/ds38/include/python3.8 -c cppsort_stdpar.cpp -o build/temp.linux-x86_64-3.8/cppsort_stdpar.o -std=c++17
```
>  nvc++-Fatal-The option -stdpar is available only on systems with NVIDIA GPUs with compute capability cc60 or greater. Please use '-gpu=ccXY' to select a compatible compute capability or remove the '-stdpar' option to generate host code.